### PR TITLE
chore: add sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [cubetribe]


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with the cubetribe GitHub Sponsors funding link.

Release impact: none.