### PR TITLE
docs: split the monolithic README into focused guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 [![Version](https://img.shields.io/badge/Version-8.0.0-blue)](./CHANGELOG.md)
 [![Architecture](https://img.shields.io/badge/Architecture-Modular%20%2B%20Skills-green)](./skills/)
-[![Agents](https://img.shields.io/badge/Agents-8%20Core%20%2B%201%20Security%20%2B%206%20Dept-purple)](./agents/)
+[![Agents](https://img.shields.io/badge/Agents-8%20Core%20%2B%201%20Security%20%2B%206%20Dept-purple)](./docs/AGENTS.md)
 [![Plugin](https://img.shields.io/badge/Plugin-Ready-orange)](./CLAUDE.md)
-[![Ultracode Ready](https://img.shields.io/badge/Ultracode-Ready-brightgreen)](./docs/AGENT_MODEL_SELECTION.md)
-[![Self-Improving](https://img.shields.io/badge/Self--Improving-Yes%2C%20Really-red)](./CHANGELOG.md)
+[![Ultracode Ready](https://img.shields.io/badge/Ultracode-Ready-brightgreen)](./docs/ARCHITECTURE.md)
+[![Self-Improving](https://img.shields.io/badge/Self--Improving-Yes%2C%20Really-red)](./docs/STORY.md)
 
 </div>
 
@@ -21,15 +21,15 @@
 
 Welcome to the machine shop. Except the machines are building themselves — and they're getting better at it.
 
-**CC_GodMode v7.0.0 and v7.1.0 weren't built by hand.** They were planned, architected, implemented, validated, documented, and shipped by the exact agents defined in this repo. PRs [#22](https://github.com/cubetribe/ClaudeCode_GodMode-On/pull/22) and [#23](https://github.com/cubetribe/ClaudeCode_GodMode-On/pull/23) are proof. The orchestrator delegated to @architect for design, @builder for implementation, @validator and @tester for quality gates, and @scribe for documentation. Then it created the PR itself.
+**CC_GodMode v7.0.0, v7.1.0, and v8.0.0 weren't built by hand.** They were planned, architected, implemented, validated, documented, and shipped by the exact agents defined in this repo. v8.0.0 went further: it was produced by a **parallel dynamic workflow** — a dozen edit subagents fanned out at once, each adversarially verified by another. The orchestrator delegated, gated, and opened the PR itself.
 
-That's not marketing copy. That's what happened.
+That's not marketing copy. That's what happened — [the full story is here](./docs/STORY.md).
 
 ---
 
 ## Install in 30 Seconds
 
-CC_GodMode is a Claude Code plugin that transforms your development workflow into a self-orchestrating multi-agent system. Here's how to set it up:
+CC_GodMode is a Claude Code plugin that turns your workflow into a self-orchestrating multi-agent system.
 
 **macOS / Linux:**
 ```bash
@@ -54,7 +54,7 @@ cp ~/.claude/templates/CLAUDE-ORCHESTRATOR.md ./CLAUDE.md
 claude
 ```
 
-Done. The orchestrator is active.
+Done. The orchestrator is active. → **Full setup, MCP servers, and prompt-based fallback: [Installation Guide](./docs/INSTALLATION.md).**
 
 ---
 
@@ -68,45 +68,13 @@ GodMode: Bug Fix: cart total miscalculates with discount codes
 GodMode: Research: best approach for real-time sync in React 18
 ```
 
-No installation ceremony. After one-time setup, most sessions need nothing — the orchestrator loads from CLAUDE.md automatically. Use the ContextRestore prompt only after /compact or if the orchestrator loses its role.
-You say what you want — the system figures out which agents to call, in what order, at what cost.
-
----
-
-## What Changed in v7 — and Why
-
-CC_GodMode v7.0.0 was redesigned around Opus 4.8, ultracode effort, and a parallel-first architecture — built on how modern Claude models actually work, not how earlier models needed to be prompted:
-
-- **Persona prompts are gone.** "You are a Senior X with 15 years of experience" adds nothing on modern Claude models like Opus 4.8 — identity is now one line, the task description does the work.
-- **Aggressive caps removed.** Extensive CRITICAL/MUST/NEVER scaffolding in older agents caused overtriggering. Per Anthropic's guidance, normal imperative phrasing is enough; hard safety rules (never push, api-guardian mandatory) keep their weight.
-- **Effort fields instead of verbose instructions.** Each agent carries an `effort:` frontmatter field (Claude Code ≥2.1.152) that tunes token budgets automatically — no long preambles needed.
-- **Smart Routing is now the default.** The old system always ran every agent. v7 runs only what the risk level requires — estimated 30–50% token reduction for standard features.
-- **Verdict contract instead of report re-reading.** Agents return a structured 3-bullet STATUS verdict to the orchestrator. The full on-disk report exists for humans and for BLOCKED escalations.
-- **Plugin-based install replaces copy-paste prompts as the primary path.** `.claude-plugin/plugin.json` is the modern distribution mechanism; the install prompts stay as a manual fallback.
-
----
-
-## The Story
-
-It started simple: One developer, mass sleep deprivation, and a vision.
-
-**Phase 1:** Manual labor. Researching best practices. Reading docs. Testing prompts. Failing. Iterating. Building agent after agent. Workflow after workflow. Week after week.
-
-**Phase 2:** The system works. 8 specialized AI agents orchestrating themselves. Features get built. Bugs get fixed. Documentation writes itself. *"This is pretty good,"* I thought.
-
-**Phase 3:** January 6th, 2026. A thought: *"What if I use the system... to improve the system?"*
-
-I gave it one prompt. The orchestrator delegated to the research team. Analyzed its own architecture. Found inefficiencies. Proposed improvements. Implemented them. Validated itself. Documented the changes.
-
-**The loop closed.**
-
-**Phase 4:** You're reading this README. An AI wrote parts of it. An AI will improve it. The experiment continues.
+No ceremony. After one-time setup the orchestrator loads from `CLAUDE.md` automatically. You say *what* you want — the system figures out *which* agents to call, in *what* order, at *what* cost.
 
 ---
 
 ## What Is This?
 
-**CC_GodMode** transforms Claude Code into a self-orchestrating multi-agent development team powered by the best / Claude Opus 4.8 orchestrator at ultracode effort, fanning work out across parallel Claude Code subagents for implementation, validation, and documentation.
+**CC_GodMode** transforms Claude Code into a self-orchestrating multi-agent development team — driven by the `best` / Claude Opus 4.8 orchestrator at **ultracode** effort, fanning work out across parallel Claude Code subagents for implementation, validation, and documentation.
 
 **You say WHAT. The AI figures out HOW.**
 
@@ -114,21 +82,18 @@ I gave it one prompt. The orchestrator delegated to the research team. Analyzed 
 You: "I need user authentication with JWT"
 
 Orchestrator:
-  → Analyzes request
-  → Determines version (5.5.0)
-  → Creates report folder
+  → Analyzes the request and determines the version bump
+  → Creates the report folder
   → Delegates to @architect for design
   → Delegates to @api-guardian for API impact
   → Delegates to @builder for implementation
-  → @validator checks code quality
-  → @tester checks UX quality
+  → @validator checks code quality  ┐ in parallel
+  → @tester checks UX quality        ┘
   → @scribe documents everything
-  → @github-manager creates PR
+  → @github-manager opens the PR
 
 You: *drinks coffee*
 ```
-
-The difference?
 
 | Without CC_GodMode | With CC_GodMode |
 |:---|:---|
@@ -141,374 +106,79 @@ The difference?
 
 ---
 
+## Parallel-First & Ultracode
+
+v8.0.0's headline: **parallelization is the default**, not an afterthought.
+
+- **Orchestrator on `best` / Opus 4.8 at ultracode** — xhigh reasoning plus automatic dynamic workflows for substantive tasks. The `best` alias auto-upgrades as your org gains access to more capable models, so the system never goes stale.
+- **Fan-out by default** — independent units (multi-file edits, audits, migrations, multi-angle research) spawn parallel subagents in a single message; the orchestrator fans in and synthesizes their verdicts.
+- **Dynamic-workflows escalation** — when a job outgrows ~10 concurrent subagents, it escalates to tens-to-hundreds of subagents with **adversarial verification** (agents try to refute each other's findings). See [`skills/dynamic-workflows/`](./skills/dynamic-workflows/SKILL.md).
+- **Smart Routing stays the default** — risk-based, minimal-agent paths; ~30–50% token reduction vs. always-Full-Gates. Parallel is *faster, not cheaper*, so max-parallel is a deliberate opt-in.
+
+→ Deep dive: [Architecture](./docs/ARCHITECTURE.md) · cost model: [Agent Model Selection](./docs/AGENT_MODEL_SELECTION.md).
+
+---
+
 ## The Agents
 
-15 specialists (8 core + 1 security gate + 6 department). Each with their own expertise, model assignment, and effort tuning.
+**15 specialists**, each with one job, a model assignment, and effort tuning:
 
-**Core agents** (8) — always available:
+- **8 core** — `@researcher` `@architect` `@api-guardian` `@builder` `@validator` `@tester` `@scribe` `@github-manager` (always available).
+- **1 security gate** — `@security`, for secrets, injection, auth/authz, crypto, and dependency review.
+- **6 department** — `@ci-security-guardian` `@docs-dx` `@quality-operations` `@runtime-platform` `@workflow-design` `@workspace-governance` (activate when their domain is in scope).
 
-| Agent | Role | Specialty |
-|:------|:-----|:----------|
-| `@researcher` | Knowledge Discovery | Web research, documentation lookup, technology evaluation |
-| `@architect` | System Architect | High-level design, module structure, tech decisions |
-| `@api-guardian` | API Lifecycle Expert | Breaking changes, consumer impact, contract validation |
-| `@builder` | Senior Developer | Implementation, following @architect's specifications |
-| `@validator` | Code Quality Gate | TypeScript, unit tests, security, consumer verification |
-| `@tester` | UX Quality Gate | E2E tests, visual regression, accessibility, performance |
-| `@scribe` | Technical Writer | Documentation, changelog, version management |
-| `@github-manager` | GitHub Manager | Issues, PRs, releases, CI/CD orchestration |
+After `@builder`, the **dual quality gates** — `@validator` (code) and `@tester` (UX) — run **in parallel** and both must pass before `@scribe` documents and ships.
 
-**Security gate** (1) — optional, activate for security-sensitive changes:
-
-| Agent | Domain | Mode |
-|:------|:-------|:-----|
-| `@security` | Secrets, injection, auth/authz, crypto, dependencies | Read + Write (security-focused) |
-
-**Department agents** (6) — optional, activate when their domain is in scope:
-
-| Agent | Domain | Mode |
-|:------|:-------|:-----|
-| `@ci-security-guardian` | GitHub Actions, CODEOWNERS, Dependabot, security | Read + Write (GitHub surface only) |
-| `@docs-dx` | Public docs, prompts, setup instructions, user-facing clarity | Read-only reviewer |
-| `@quality-operations` | Validation scope, regression gates, eval-oriented checks | Read-only advisor |
-| `@runtime-platform` | Toolchain, sandbox, environment constraints, OS behavior | Read-only + diagnostic Bash |
-| `@workflow-design` | Orchestration design, skill boundaries, handoff artifacts | Read-only designer |
-| `@workspace-governance` | AGENTS layering, repo rules, release law, change-scope policy | Read-only reviewer |
-
-**Dual Quality Gates:**
-
-```
-                    @builder completes
-                           │
-           ┌───────────────┴───────────────┐
-           ▼                               ▼
-    ┌─────────────┐                 ┌─────────────┐
-    │ @validator  │                 │  @tester    │
-    │ Code Quality│                 │ UX Quality  │
-    ├─────────────┤                 ├─────────────┤
-    │ ✓ TypeScript│                 │ ✓ E2E Tests │
-    │ ✓ Unit Tests│                 │ ✓ Visuals   │
-    │ ✓ Security  │                 │ ✓ A11y      │
-    │ ✓ Consumers │                 │ ✓ Perf      │
-    └──────┬──────┘                 └──────┬──────┘
-           │                               │
-           └───────────────┬───────────────┘
-                           ▼
-                   Both gates passed?
-                   → Continue to @scribe
-```
-
----
-
-## Ultracode & Parallel-First
-
-CC_GodMode v8.0.0 runs on a **parallel-first, ultracode orchestrator** with model-tiered Claude Code subagents (haiku for simple ops, sonnet for implementation, opus for architecture) and effort-field budget tuning.
-
-**How it works:**
-- **The orchestrator (best / Opus 4.8 at ultracode)** — classifies risk, writes inline architecture briefs, fans work out across parallel subagents, and reads only what it needs.
-- **Parallel fan-out by default** — when a request decomposes into independent units (multi-file edits, multi-domain work, audits, migrations), the orchestrator spawns parallel subagents in a single message rather than sequentially, then collects and synthesizes their verdicts.
-- **Dynamic-workflows escalation** — when a job outgrows ~10 concurrent subagents (codebase-wide audits, large migrations, cross-checked research), the orchestrator escalates to dynamic workflows (`/workflows` or ultracode) with adversarial verification across tens-to-hundreds of subagents.
-- **Subagents stay cheap** — builder/validator/tester on sonnet, scribe/researcher/github-manager on haiku, architect on opus only when genuinely needed.
-- **Effort fields** — each agent's `effort` frontmatter field (Claude Code ≥2.1.152) tunes token budgets automatically: architect=high, builder/tester/api-guardian=medium, all others=low.
-- **Smart Routing default** — risk-based minimal-agent paths replace the old "always Full-Gates" default, estimated 30–50% token reduction per standard feature vs. the previous always-Full-Gates default (based on per-workflow cost models in docs/AGENT_MODEL_SELECTION.md).
-- **Full-Gates on demand** — API/schema changes, security surfaces, release artifacts, new modules, and breaking changes automatically escalate to the full agent sequence.
-- **Cost guardrail** — parallel = faster, not cheaper; dynamic workflows multiply token spend. Smart Routing stays the default; max-parallel / dynamic-workflows is an explicit, deliberate opt-in for big or time-critical jobs.
-
-**Token efficiency per workflow type:**
-| Workflow | Smart Routing | Full-Gates |
-|:---------|:-------------|:-----------|
-| Simple bug fix | @builder + scoped gates | all agents |
-| Docs-only | @scribe only | — |
-| Standard feature | inline brief + @builder + scoped gates | @architect + full sequence |
-| API change | always Full-Gates (mandatory @api-guardian) | always Full-Gates |
-
----
-
-## The Architecture (v7.0)
-
-**v6.0 modular architecture. v6.1 Skills. v6.2 worktree isolation. v6.3 Plugin packaging. v6.4 Workflow Modes. v7.0 orchestrator tuning + Smart Routing default. v7.1 @security gate + installer scripts → 15 agents. v8.0 Ultracode orchestrator + parallel-first architecture.**
-
-```
-~/.claude/                          ← RUNTIME (What Claude loads)
-├── agents/                         ← 15 agents (8 core + 1 security gate + 6 department), globally available
-│   ├── researcher.md               ← haiku, effort: low
-│   ├── architect.md                ← opus, effort: high
-│   ├── api-guardian.md             ← sonnet, effort: medium
-│   ├── builder.md                  ← sonnet, effort: medium
-│   ├── validator.md                ← sonnet, effort: low
-│   ├── tester.md                   ← sonnet, effort: medium
-│   ├── scribe.md                   ← haiku, effort: low
-│   ├── github-manager.md           ← haiku, effort: low
-│   ├── ci-security-guardian.md     ← sonnet, effort: low (dept.)
-│   ├── docs-dx.md                  ← sonnet, effort: low (dept.)
-│   ├── quality-operations.md       ← sonnet, effort: low (dept.)
-│   ├── runtime-platform.md         ← sonnet, effort: low (dept.)
-│   ├── workflow-design.md          ← sonnet, effort: low (dept.)
-│   └── workspace-governance.md     ← sonnet, effort: low (dept.)
-├── scripts/                        ← Hook scripts
-│   ├── session-start.js
-│   ├── validate-agent-output.js
-│   └── check-api-impact.js
-└── settings.json                   ← Hooks (SessionStart, PostToolUse,
-                                       SubagentStop, TaskCompleted)
-```
-
-```
-your-project/                       ← YOUR PROJECT
-├── CLAUDE.md                       ← Orchestrator (~65 lines, auto-loaded!)
-├── VERSION                         ← Single source of truth
-├── CHANGELOG.md                    ← Version history
-├── docs/orchestrator/              ← NEW v6.0: Modular reference docs
-│   ├── AGENTS.md                   ← Agent registry & handoff matrix
-│   ├── WORKFLOWS.md                ← All 7 workflow definitions
-│   ├── MODES.md                    ← Smart Routing, Prototype, Departments, Cost-Efficiency
-│   ├── QUALITY-GATES.md            ← Parallel gate orchestration
-│   ├── VERSIONING.md               ← Version-first & pre-push rules
-│   └── META-DECISIONS.md           ← Meta-logic, ADR, RARE, escalation
-├── reports/                        ← Agent outputs (gitignored)
-│   └── vX.X.X/                     ← Grouped by version
-└── .playwright-mcp/                ← Screenshot output
-```
-
-**The trick:** `CLAUDE.md` is automatically loaded by Claude Code. The 65 lines contain core rules. Detailed docs load on-demand — less context waste, more focus.
-
----
-
-## Agent Architecture
-
-CC_GodMode uses a **dual-location model** for agents:
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                    AGENT DUAL-LOCATION MODEL                         │
-├─────────────────────────────────────────────────────────────────────┤
-│                                                                      │
-│   GitHub Repository                    Your System                   │
-│   ════════════════                    ════════════                   │
-│                                                                      │
-│   CC_GodMode/                         ~/.claude/                     │
-│   └── agents/           ──INSTALL──►  └── agents/                   │
-│       ├── architect.md  (15 files)        ├── architect.md          │
-│       ├── builder.md                      ├── builder.md            │
-│       ├── validator.md                    ├── validator.md          │
-│       ├── ...8 core...                    ├── ...8 core...          │
-│       └── ...6 dept...                    └── ...6 dept...          │
-│                                                                      │
-│   📦 SOURCE                            🚀 RUNTIME                    │
-│   • Version controlled                 • Actually loaded by Claude   │
-│   • Templates for Git                  • System-wide available       │
-│   • Update here, reinstall             • Used during workflows       │
-│                                                                      │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-**Why this design?**
-- **Source** (`/agents/`): Tracked in Git, shareable, updatable
-- **Runtime** (`~/.claude/agents/`): Where Claude Code actually looks for agents
-
-**Update flow:**
-1. Modify agent in `/agents/` (source)
-2. Run installation script
-3. Changes copied to `~/.claude/agents/` (runtime)
-4. Claude Code uses updated agents
-
----
-
-## The Workflows
-
-The Orchestrator selects the right workflow automatically:
-
-**New Feature:**
-```
-(@researcher)* → @architect → @builder → (@validator ∥ @tester) → @scribe
-```
-
-**Bug Fix:**
-```
-@builder → (@validator ∥ @tester)
-```
-
-**API Change (Critical!):**
-```
-(@researcher)* → @architect → @api-guardian → @builder → (@validator ∥ @tester) → @scribe
-```
-
-**Refactoring:**
-```
-@architect → @builder → (@validator ∥ @tester)
-```
-
-**Research Task:**
-```
-@researcher → report with sources
-```
-
-*\* @researcher is optional - use when new tech/library research is needed*
-
-**Note:** Quality gates run in PARALLEL (∥ symbol) for faster validation.
-
-**Release:**
-```
-@scribe → @github-manager
-```
-
-## Workflow Modes
-
-v7.0 inverts routing: Smart Routing is now the default, Full-Gates is the explicit escalation path for high-risk work.
-
-| Mode | Skill | Purpose |
-|:-----|:------|:--------|
-| **Smart Routing (default)** | `skills/cost-efficiency/` | Risk-based minimal-agent paths, inline arch brief for small/medium tasks |
-| Full-Gates | `skills/workflows/` | High-risk work: new modules, API/breaking changes, security, release artifacts |
-| Prototype | `skills/prototype-mode/` | Local-only spikes with `PROTOTYPE ONLY` watermarks and a migration checklist |
-| Departments | `skills/departments/` | Expanded cross-domain orchestration with frozen ownership and write scopes |
-| Agent Teams | `skills/agent-teams/` | Experimental teammate-style parallelism when explicitly requested |
-
-Prototype Mode is the only mode that intentionally skips production gates. It
-must not be pushed, deployed, or connected to production systems. Promotion
-always goes back through the Full-Gates workflow.
-
----
-
-## The Hook
-
-The secret ingredient: A PostToolUse hook that runs after every file change.
-
-```
-Developer changes: shared/types/User.ts
-                          │
-                          ▼
-              ┌───────────────────────┐
-              │  check-api-impact.js  │  ← AUTOMATICALLY
-              │                       │
-              │  • Detects API change │
-              │  • Analyzes diff      │
-              │  • Finds consumers    │
-              │  • Warns about breaks │
-              └───────────────────────┘
-                          │
-                          ▼
-╔═══════════════════════════════════════════════════════════╗
-║  ⚠️  API/TYPE FILE CHANGE DETECTED                         ║
-║                                                            ║
-║  📁 File: shared/types/User.ts                             ║
-║  🔴 BREAKING: Removed field 'email'                        ║
-║  📍 5 consumers found                                      ║
-║                                                            ║
-║  ⚡ @api-guardian MUST be called!                          ║
-╚═══════════════════════════════════════════════════════════╝
-```
-
-Nothing gets forgotten. The hook remembers for you.
-
----
-
-## Recommended MCP Servers
-
-Enhanced capabilities through Model Context Protocol (installed in the setup script, but optional):
-
-```bash
-# Memory (recommended for agents)
-claude mcp add memory -- npx -y @modelcontextprotocol/server-memory
-
-# Browser automation & screenshots (required for @tester)
-claude mcp add playwright -- npx @playwright/mcp@latest
-
-# GitHub (recommended for @github-manager)
-export GITHUB_TOKEN="your_token"
-claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_TOKEN \
-  -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN \
-  ghcr.io/github/github-mcp-server
-
-# Performance audits (optional)
-claude mcp add lighthouse -- npx lighthouse-mcp
-
-# Accessibility testing (optional)
-claude mcp add a11y -- npx a11y-mcp
-```
-
----
-
-## Backup Install Methods (Fallback)
-
-If the script doesn't work on your system, you have fallback options:
-
-**Manual prompt install (guided, copy-paste):**
-1. [`CCGM_Prompt_01-SystemInstall-Auto.md`](./CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Auto.md) — One-shot automated (requires `--dangerously-skip-permissions`)
-2. [`CCGM_Prompt_01-SystemInstall-Manual.md`](./CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Manual.md) — Step-by-step (manual control)
-
-For updates and troubleshooting:
-- [`CCGM_Prompt_98-Maintenance.md`](./CC-GodMode-Prompts/CCGM_Prompt_98-Maintenance.md) — Pull agent and skill improvements
-- [`CCGM_Prompt_99-ContextRestore.md`](./CC-GodMode-Prompts/CCGM_Prompt_99-ContextRestore.md) — Restore orchestrator after `/compact`
-
-**When you need context recovery:**
-
-The orchestrator is active when `CLAUDE.md` is present. Use the context-restore prompt if:
-- Claude writes code instead of delegating
-- Claude forgets to call @api-guardian for API changes
-- Claude skips quality gates
-- Claude tries to push without permission
-
-Otherwise, just type `GodMode: <your request>`.
+→ Full roster, quality gates, and workflows: **[The Agents](./docs/AGENTS.md)**.
 
 ---
 
 ## The Rules
 
-1. **Version-First** — Determine version BEFORE any work starts
+1. **Version-First** — Determine the version BEFORE any work starts
 2. **Smart Routing default** — Risk-based routing; Full-Gates for high-risk signals
-3. **Architecture gate (split)** — Inline brief for small/medium; @architect (Opus) for new modules/breaking changes
+3. **Architecture gate (split)** — Inline brief for small/medium; @architect (Opus) for new modules / breaking changes
 4. **@api-guardian is MANDATORY** — For any API/schema/type change (enforced by hook)
 5. **Dual Quality Gates** — Both @validator AND @tester must pass (parallel execution)
-6. **@tester MUST create Screenshots** — Every page tested at 3 viewports
-7. **No Skipping** — Every agent in workflow executes
-8. **Reports in reports/vX.X.X/** — Organized by version
+6. **@tester MUST create screenshots** — Every page tested at 3 viewports
+7. **No Skipping** — Every agent in the workflow executes
+8. **Reports in `reports/vX.X.X/`** — Organized by version
 9. **NEVER push without permission** — Applies to ALL agents
 
 ---
 
 ## Documentation
 
-CC_GodMode includes comprehensive documentation for understanding and extending the system:
+**Guides** (start here):
+- **[Installation Guide](./docs/INSTALLATION.md)** — script install, MCP servers, prompt-based fallback, recovery
+- **[Architecture](./docs/ARCHITECTURE.md)** — parallel-first orchestration, file structure, dual-location model, the hook
+- **[The Agents](./docs/AGENTS.md)** — the 15-agent roster, quality gates, workflows, and modes
+- **[The Story & Design Philosophy](./docs/STORY.md)** — how (and why) the system builds itself
 
-### Core Documentation
-- **[CHANGELOG.md](./CHANGELOG.md)** - Full version history and evolution of the system
-- **[AGENT_ARCHITECTURE.md](./docs/AGENT_ARCHITECTURE.md)** - Understanding the dual-location model
-- **[AGENT_MODEL_SELECTION.md](./docs/AGENT_MODEL_SELECTION.md)** - Cost optimization and ROI analysis
-- **[MODES.md](./docs/orchestrator/MODES.md)** - Smart Routing (default), Full-Gates, Prototype, Departments, Agent Teams, and Cost-Efficiency routing
+**Reference:**
+- **[CHANGELOG.md](./CHANGELOG.md)** — full version history
+- **[AGENT_MODEL_SELECTION.md](./docs/AGENT_MODEL_SELECTION.md)** — model aliases, pricing, and cost optimization
+- **[AGENT_ARCHITECTURE.md](./docs/AGENT_ARCHITECTURE.md)** — dual-location install/update/verify procedures
+- **[orchestrator/AGENTS.md](./docs/orchestrator/AGENTS.md)** — agent registry & handoff matrix
+- **[orchestrator/WORKFLOWS.md](./docs/orchestrator/WORKFLOWS.md)** · **[MODES.md](./docs/orchestrator/MODES.md)** · **[QUALITY-GATES.md](./docs/orchestrator/QUALITY-GATES.md)** · **[VERSIONING.md](./docs/orchestrator/VERSIONING.md)** · **[META-DECISIONS.md](./docs/orchestrator/META-DECISIONS.md)**
 
-### Policy Documents
-- **[REPORT_TEMPLATES.md](./docs/templates/REPORT_TEMPLATES.md)** - Standardized formats for all 15 agents
-- **[CONTEXT_SCOPE_POLICY.md](./docs/policies/CONTEXT_SCOPE_POLICY.md)** - Agent boundaries and responsibilities
-- **[SECURITY_TOOLING_POLICY.md](./docs/policies/SECURITY_TOOLING_POLICY.md)** - Tool access control matrix
+**Policies:**
+- **[REPORT_TEMPLATES.md](./docs/templates/REPORT_TEMPLATES.md)** · **[CONTEXT_SCOPE_POLICY.md](./docs/policies/CONTEXT_SCOPE_POLICY.md)** · **[SECURITY_TOOLING_POLICY.md](./docs/policies/SECURITY_TOOLING_POLICY.md)**
 
-These documents transform implicit knowledge into explicit contracts, making the system more maintainable and predictable.
-
+---
 
 ## FAQ
 
 **Q: Why 15 agents?**
-A: 8 core agents cover the standard workflow. 1 optional @security gate activates for security-sensitive changes. 6 optional department agents activate only when their domain is in scope — CI/security, docs, quality ops, platform, workflow design, governance. Separation of concerns: each agent has ONE job.
+A: 8 core cover the standard workflow, 1 optional `@security` gate activates for security-sensitive changes, and 6 optional department agents activate only when their domain is in scope. Separation of concerns — each agent has ONE job.
 
 **Q: What's the difference between @validator and @tester?**
-A: @validator = code quality (TypeScript, tests, security). @tester = UX quality (E2E, visual, a11y, perf).
+A: `@validator` = code quality (TypeScript, tests, security). `@tester` = UX quality (E2E, visual, a11y, perf). They run in parallel.
 
-**Q: Can I skip @tester?**
-A: For backend-only changes, yes. For anything UI-related, no.
-
-**Q: Can agents push without your permission?**
+**Q: Can agents push without my permission?**
 A: No. "NEVER git push without permission" is enforced across all agents.
 
-**Q: Is this just... AI improving AI?**
-A: Yes. That's the unsettling part. And the fascinating part. Same thing, really.
-
----
-
-## The Meta
-
-This README was partly written by an AI.
-The system that wrote it will improve it.
-The loop continues.
+→ More, plus the origin story: [The Story & Design Philosophy](./docs/STORY.md).
 
 ---
 
@@ -516,21 +186,15 @@ The loop continues.
 
 **CC_GodMode v8.0.0 — The Ultracode Release**
 
-Latest releases:
-- **v8.0.0:** Ultracode orchestrator (best / Opus 4.8 at ultracode), parallel-first architecture, new dynamic-workflows skill + Ultracode/Max-Parallel mode, branding migrated to Opus/ultracode
-- **v7.1.1:** README overhaul, self-improving narrative, consolidated install quickstart, improved docs structure
-- **v7.1.0:** Installer/verifier scripts, @security gate agent, greenfield-bootstrap skill, dependabot + CODEOWNERS
-- **v7.0.0:** Orchestrator tuning + Smart Routing default, 15 agents (8 core + 1 security + 6 dept), effort fields, verdict contract
-
 What's in the box:
 - **15 agents** (8 core + 1 security gate + 6 department) with effort-field budget tuning
-- **12 skills** for workflows, quality gates, release, research, API changes, modes, teams, and bootstrap
+- **13 skills** for workflows, quality gates, release, research, API changes, modes, teams, bootstrap, and dynamic workflows
+- **Parallel-first orchestration** — fan-out by default, dynamic-workflows escalation with adversarial verification
 - **Dual quality gates** (parallel execution for speed)
-- **Smart Routing by default** (30–50% token savings vs. old always-Full-Gates)
-- **Full-Gates escalation** for high-risk work: API/schema changes, security, release artifacts, new modules
+- **Smart Routing by default** (~30–50% token savings vs. old always-Full-Gates)
 - **Version-first workflow** with automated checks
 
-See [CHANGELOG.md](./CHANGELOG.md) for the full history.
+See the [CHANGELOG](./CHANGELOG.md) for the full history.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,151 @@
+# The Agents
+
+15 specialists (8 core + 1 security gate + 6 department), each with one job, its own model assignment, and effort tuning.
+
+This is the human-facing roster; for the machine handoff matrix see [orchestrator/AGENTS.md](./orchestrator/AGENTS.md), and for per-agent model/cost rationale see [AGENT_MODEL_SELECTION.md](./AGENT_MODEL_SELECTION.md).
+
+---
+
+## Core Agents (8)
+
+Always available. The Orchestrator selects from these on every workflow run.
+
+| Agent | Role | Specialty |
+|:------|:-----|:----------|
+| `@researcher` | Knowledge Discovery | Web research, documentation lookup, technology evaluation |
+| `@architect` | System Architect | High-level design, module structure, tech decisions |
+| `@api-guardian` | API Lifecycle Expert | Breaking changes, consumer impact, contract validation |
+| `@builder` | Senior Developer | Implementation, following @architect's specifications |
+| `@validator` | Code Quality Gate | TypeScript, unit tests, security, consumer verification |
+| `@tester` | UX Quality Gate | E2E tests, visual regression, accessibility, performance |
+| `@scribe` | Technical Writer | Documentation, changelog, version management |
+| `@github-manager` | GitHub Manager | Issues, PRs, releases, CI/CD orchestration |
+
+---
+
+## Security Gate (1)
+
+Optional. Activate for any change that touches secrets, auth/authz, crypto, injection surfaces, or dependency trust.
+
+| Agent | Domain | Mode |
+|:------|:-------|:-----|
+| `@security` | Secrets, injection, auth/authz, crypto, dependencies | Read + Write (security-focused) |
+
+---
+
+## Department Agents (6)
+
+Optional. The Orchestrator activates them when a task touches their domain.
+
+| Agent | Domain | Mode |
+|:------|:-------|:-----|
+| `@ci-security-guardian` | GitHub Actions, CODEOWNERS, Dependabot, security | Read + Write (GitHub surface only) |
+| `@docs-dx` | Public docs, prompts, setup instructions, user-facing clarity | Read-only reviewer |
+| `@quality-operations` | Validation scope, regression gates, eval-oriented checks | Read-only advisor |
+| `@runtime-platform` | Toolchain, sandbox, environment constraints, OS behavior | Read-only + diagnostic Bash |
+| `@workflow-design` | Orchestration design, skill boundaries, handoff artifacts | Read-only designer |
+| `@workspace-governance` | AGENTS layering, repo rules, release law, change-scope policy | Read-only reviewer |
+
+---
+
+## Dual Quality Gates
+
+@validator and @tester run in **PARALLEL** after @builder — both must pass before the workflow continues. Neither gate can be skipped.
+
+```
+                    @builder completes
+                           │
+           ┌───────────────┴───────────────┐
+           ▼                               ▼
+    ┌─────────────┐                 ┌─────────────┐
+    │ @validator  │                 │  @tester    │
+    │ Code Quality│                 │ UX Quality  │
+    ├─────────────┤                 ├─────────────┤
+    │ ✓ TypeScript│                 │ ✓ E2E Tests │
+    │ ✓ Unit Tests│                 │ ✓ Visuals   │
+    │ ✓ Security  │                 │ ✓ A11y      │
+    │ ✓ Consumers │                 │ ✓ Perf      │
+    └──────┬──────┘                 └──────┬──────┘
+           │                               │
+           └───────────────┬───────────────┘
+                           ▼
+                   Both gates passed?
+                   → Continue to @scribe
+```
+
+If either gate returns `BLOCKED`, the Orchestrator merges the feedback and sends it back to @builder before re-running both gates.
+
+---
+
+## Workflows
+
+The Orchestrator selects the right workflow automatically based on request type and risk classification.
+
+**New Feature:**
+```
+(@researcher)* → @architect → @builder → (@validator ∥ @tester) → @scribe
+```
+
+**Bug Fix:**
+```
+@builder → (@validator ∥ @tester)
+```
+
+**API Change (Critical!):**
+```
+(@researcher)* → @architect → @api-guardian → @builder → (@validator ∥ @tester) → @scribe
+```
+
+**Refactoring:**
+```
+@architect → @builder → (@validator ∥ @tester)
+```
+
+**Research Task:**
+```
+@researcher → report with sources
+```
+
+**Release:**
+```
+@scribe → @github-manager
+```
+
+*\* @researcher is optional — invoke when new tech or library evaluation is needed before design decisions.*
+
+**Note:** The `∥` symbol means the gates run in **PARALLEL** for faster validation. Both must pass.
+
+For full workflow definitions including API change protocol and issue processing, see [orchestrator/WORKFLOWS.md](./orchestrator/WORKFLOWS.md).
+
+---
+
+## Workflow Modes
+
+v7.0 inverted routing: Smart Routing is the default, Full-Gates is the explicit escalation path for high-risk work.
+
+| Mode | Skill | Purpose |
+|:-----|:------|:--------|
+| **Smart Routing (default)** | `skills/cost-efficiency/` | Risk-based minimal-agent paths, inline arch brief for small/medium tasks |
+| Full-Gates | `skills/workflows/` | High-risk work: new modules, API/breaking changes, security, release artifacts |
+| Prototype | `skills/prototype-mode/` | Local-only spikes with `PROTOTYPE ONLY` watermarks and a migration checklist |
+| Departments | `skills/departments/` | Expanded cross-domain orchestration with frozen ownership and write scopes |
+| Agent Teams | `skills/agent-teams/` | Experimental teammate-style parallelism when explicitly requested |
+| **Ultracode / Max-Parallel** | `skills/dynamic-workflows/` | Large, decomposable jobs (codebase-wide audits, big migrations, cross-checked research); fans out to tens-to-hundreds of verified parallel subagents — opt-in, higher token spend |
+
+**Mode selection notes:**
+
+- Prototype Mode is the only mode that intentionally skips production gates. It must not be pushed, deployed, or connected to production systems. Promotion always goes back through the Full-Gates workflow.
+- Ultracode / Max-Parallel is a deliberate opt-in. Parallel execution is faster, not cheaper — dynamic workflows multiply token spend. Smart Routing stays the default for everyday work.
+
+For full mode definitions and routing rules, see [orchestrator/MODES.md](./orchestrator/MODES.md).
+
+---
+
+## See Also
+
+- [../README.md](../README.md) — Project overview and quick-start
+- [./orchestrator/AGENTS.md](./orchestrator/AGENTS.md) — Machine handoff matrix and agent registry
+- [./orchestrator/WORKFLOWS.md](./orchestrator/WORKFLOWS.md) — Full workflow definitions
+- [./orchestrator/MODES.md](./orchestrator/MODES.md) — Routing mode details and skill boundaries
+- [./orchestrator/QUALITY-GATES.md](./orchestrator/QUALITY-GATES.md) — Parallel gate orchestration and decision matrix
+- [./AGENT_MODEL_SELECTION.md](./AGENT_MODEL_SELECTION.md) — Per-agent model assignment and cost rationale

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,192 @@
+# Architecture
+
+A reference guide to how CC_GodMode is structured, how its orchestrator thinks, and why the pieces live where they do.
+
+---
+
+## Parallel-First & Ultracode Orchestration
+
+The orchestrator runs on `best` (Opus 4.8, auto-upgrades as higher tiers become available) at **ultracode** effort — maximum reasoning plus automatic dynamic workflows for substantive tasks. Everything else follows from that single decision.
+
+**How it works:**
+
+- **Parallel fan-out is the default.** When a request decomposes into independent units (multi-file edits, multi-domain work, audits, migrations, multi-angle research), the orchestrator spawns multiple subagents in a single message rather than sequentially, then collects and synthesizes their verdicts.
+- **Dynamic-workflows escalation.** When a job outgrows ~10 concurrent subagents — codebase-wide audits, large migrations, cross-checked research — the orchestrator escalates to dynamic workflows (`/workflows` or ultracode) with adversarial verification across tens-to-hundreds of subagents.
+- **Subagents stay on tiered aliases.** haiku for simple ops, sonnet for implementation, opus for architecture. Only genuinely hard problems justify the expensive tier.
+- **Effort fields tune token budgets.** Each agent's `effort` frontmatter field (requires Claude Code ≥2.1.152) tells the runtime how hard to think: architect=high, builder/tester/api-guardian=medium, everything else=low.
+- **Smart Routing is the default.** Risk-based, minimal-agent paths replace the old always-Full-Gates default. Estimated 30–50% token reduction per standard feature (based on per-workflow cost models in `docs/AGENT_MODEL_SELECTION.md`).
+- **Full-Gates activates automatically** for API/schema changes, security surfaces, release artifacts, new modules, and breaking changes.
+- **Cost guardrail.** Parallel means faster, not cheaper. Dynamic workflows multiply token spend. Max-parallel and dynamic-workflows are explicit, deliberate opt-ins for big or time-critical jobs — Smart Routing stays the default.
+
+**Token efficiency per workflow type:**
+
+| Workflow | Smart Routing | Full-Gates |
+|:---------|:-------------|:-----------|
+| Simple bug fix | @builder + scoped gates | all agents |
+| Docs-only | @scribe only | — |
+| Standard feature | inline brief + @builder + scoped gates | @architect + full sequence |
+| API change | always Full-Gates (mandatory @api-guardian) | always Full-Gates |
+
+**The four parallelization surfaces:**
+
+| Surface | What it is | Use when |
+|:--------|:-----------|:---------|
+| **Subagents** | Delegated workers inside one session, own context, return a summary | A side task would flood the main context; up to ~10 run concurrently, the rest queue |
+| **Agent view** (`claude agents`) | Dispatch + monitor background sessions | Several independent hand-off tasks you check on later |
+| **Agent teams** | Coordinated sessions, shared task list, inter-agent messaging, lead-managed | Split a project, assign pieces, keep workers in sync (experimental, off by default) |
+| **Dynamic workflows** (`/workflows`) | Script runs many subagents + adversarial cross-checks | Job outgrows a handful of subagents: codebase-wide audit, 500-file migration, cross-checked research |
+
+---
+
+## File Structure
+
+Two trees, two purposes. The runtime tree is what Claude Code loads. The project tree is what you ship.
+
+**Runtime — `~/.claude/` (what Claude loads)**
+
+```
+~/.claude/                          ← RUNTIME (What Claude loads)
+├── agents/                         ← 15 agents (8 core + 1 security gate + 6 department), globally available
+│   ├── researcher.md               ← haiku, effort: low
+│   ├── architect.md                ← opus, effort: high
+│   ├── api-guardian.md             ← sonnet, effort: medium
+│   ├── builder.md                  ← sonnet, effort: medium
+│   ├── validator.md                ← sonnet, effort: low
+│   ├── tester.md                   ← sonnet, effort: medium
+│   ├── scribe.md                   ← haiku, effort: low
+│   ├── github-manager.md           ← haiku, effort: low
+│   ├── security.md                 ← opus, effort: low  (security gate, optional)
+│   ├── ci-security-guardian.md     ← sonnet, effort: low (dept.)
+│   ├── docs-dx.md                  ← sonnet, effort: low (dept.)
+│   ├── quality-operations.md       ← sonnet, effort: low (dept.)
+│   ├── runtime-platform.md         ← sonnet, effort: low (dept.)
+│   ├── workflow-design.md          ← sonnet, effort: low (dept.)
+│   └── workspace-governance.md     ← sonnet, effort: low (dept.)
+├── scripts/                        ← Hook scripts
+│   ├── session-start.js
+│   ├── validate-agent-output.js
+│   └── check-api-impact.js
+└── settings.json                   ← Hooks (SessionStart, PostToolUse,
+                                       SubagentStop, TaskCompleted)
+```
+
+**Your project**
+
+```
+your-project/                       ← YOUR PROJECT
+├── CLAUDE.md                       ← Orchestrator (~65 lines, auto-loaded!)
+├── VERSION                         ← Single source of truth
+├── CHANGELOG.md                    ← Version history
+├── docs/orchestrator/              ← Modular reference docs
+│   ├── AGENTS.md                   ← Agent registry & handoff matrix
+│   ├── WORKFLOWS.md                ← All workflow definitions
+│   ├── MODES.md                    ← Smart Routing, Prototype, Departments, Cost-Efficiency
+│   ├── QUALITY-GATES.md            ← Parallel gate orchestration
+│   ├── VERSIONING.md               ← Version-first & pre-push rules
+│   └── META-DECISIONS.md           ← Meta-logic, ADR, RARE, escalation
+├── reports/                        ← Agent outputs (gitignored)
+│   └── vX.X.X/                     ← Grouped by version
+└── .playwright-mcp/                ← Screenshot output
+```
+
+`CLAUDE.md` is auto-loaded by Claude Code on every session. The 65 lines contain the core rules; the 13 skills in `skills/` load on-demand so context stays focused.
+
+---
+
+## The Dual-Location Model
+
+CC_GodMode separates where agents live from where Claude reads them.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    AGENT DUAL-LOCATION MODEL                         │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│   GitHub Repository                    Your System                   │
+│   ════════════════                    ════════════                   │
+│                                                                      │
+│   CC_GodMode/                         ~/.claude/                     │
+│   └── agents/           ──INSTALL──►  └── agents/                   │
+│       ├── architect.md  (15 files)        ├── architect.md          │
+│       ├── builder.md                      ├── builder.md            │
+│       ├── validator.md                    ├── validator.md          │
+│       ├── ...8 core...                    ├── ...8 core...          │
+│       └── ...6 dept...                    └── ...6 dept...          │
+│                                                                      │
+│   SOURCE                               RUNTIME                       │
+│   • Version controlled                 • Actually loaded by Claude   │
+│   • Templates for Git                  • System-wide available       │
+│   • Update here, reinstall             • Used during workflows       │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Source** (`/agents/` in the repo) is tracked in Git — shareable, diffable, PR-reviewable. **Runtime** (`~/.claude/agents/`) is where Claude Code looks when it resolves a `subagent_type`. They are not the same directory; changes to source only take effect after an install step copies them to runtime.
+
+**Update flow in brief:**
+1. Modify an agent file in `agents/` (source)
+2. Run the installation script
+3. Files are copied to `~/.claude/agents/` (runtime)
+4. Claude Code picks up the updated agent on the next task
+
+For full install, update, and verification procedures — including the installer scripts, manual fallback steps, and how to confirm the right version is live — see [`./AGENT_ARCHITECTURE.md`](./AGENT_ARCHITECTURE.md).
+
+---
+
+## The Hook
+
+The secret ingredient: a PostToolUse hook that fires after every file write.
+
+```
+Developer changes: shared/types/User.ts
+                          │
+                          ▼
+              ┌───────────────────────┐
+              │  check-api-impact.js  │  ← AUTOMATICALLY
+              │                       │
+              │  • Detects API change │
+              │  • Analyzes diff      │
+              │  • Finds consumers    │
+              │  • Warns about breaks │
+              └───────────────────────┘
+                          │
+                          ▼
+╔═══════════════════════════════════════════════════════════╗
+║  ⚠️  API/TYPE FILE CHANGE DETECTED                         ║
+║                                                            ║
+║  📁 File: shared/types/User.ts                             ║
+║  🔴 BREAKING: Removed field 'email'                        ║
+║  📍 5 consumers found                                      ║
+║                                                            ║
+║  ⚡ @api-guardian MUST be called!                          ║
+╚═══════════════════════════════════════════════════════════╝
+```
+
+`check-api-impact.js` watches for writes to API-critical paths (`src/api/`, `backend/routes/`, `shared/types/`, `*.d.ts`, `openapi.yaml`), diffs the change, discovers downstream consumers, and blocks the workflow until @api-guardian has signed off. Nothing gets forgotten — the hook remembers so the orchestrator doesn't have to.
+
+---
+
+## Evolution
+
+The architecture has a clear lineage:
+
+**v6.0** modular architecture →
+**v6.1** Skills system (on-demand knowledge, 13 skills) →
+**v6.2** worktree isolation →
+**v6.3** plugin packaging →
+**v6.4** Workflow Modes →
+**v7.0** orchestrator tuning + Smart Routing default →
+**v7.1** @security gate + installer scripts (15 agents total) →
+**v8.0** Ultracode orchestrator + parallel-first architecture
+
+Each step is additive. The core contract — `CLAUDE.md` auto-loads, agents live in `~/.claude/agents/`, skills load on demand — has been stable since v6.0.
+
+---
+
+## See Also
+
+- [`../README.md`](../README.md) — project overview and quick-start
+- [`./AGENT_ARCHITECTURE.md`](./AGENT_ARCHITECTURE.md) — full agent install, update, and verification procedures
+- [`./AGENT_MODEL_SELECTION.md`](./AGENT_MODEL_SELECTION.md) — model and effort matrix per agent, cost models
+- [`./orchestrator/MODES.md`](./orchestrator/MODES.md) — Smart Routing, Full-Gates, Prototype, Departments, Agent Teams, Ultracode
+- [`../skills/dynamic-workflows/SKILL.md`](../skills/dynamic-workflows/SKILL.md) — when and how to escalate to dynamic workflows with adversarial verification

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,149 @@
+# Installation Guide
+
+CC_GodMode is a Claude Code plugin that transforms your development workflow into a self-orchestrating multi-agent system. This guide covers every installation path from the fast track to manual fallbacks.
+
+---
+
+## Requirements
+
+- **Node.js 18+** — required by the MCP servers (memory, playwright, etc.)
+- **Claude Code ≥ 2.1.152** — required for agent `effort` frontmatter fields and subagent dispatch
+- **git** — required to clone the repo and to keep GodMode up to date
+
+---
+
+## Quick Install (recommended)
+
+Clone the repo once, then run the platform-appropriate setup script. The script installs agents, skills, and templates into `~/.claude/` globally.
+
+**macOS / Linux:**
+```bash
+git clone https://github.com/cubetribe/ClaudeCode_GodMode-On.git
+cd ClaudeCode_GodMode-On
+./scripts/apply-global-claude-setup.sh
+./scripts/apply-global-claude-setup.sh --check   # Verify installation
+```
+
+**Windows (PowerShell):**
+```powershell
+git clone https://github.com/cubetribe/ClaudeCode_GodMode-On.git
+cd ClaudeCode_GodMode-On
+.\scripts\apply-global-claude-setup.ps1
+.\scripts\apply-global-claude-setup.ps1 -Check   # Verify installation
+```
+
+The `--check` / `-Check` flag re-runs the script in verification mode: it confirms that all agents, skills, and templates were placed correctly without making further changes.
+
+---
+
+## Activate in a Project
+
+After installation, activate the orchestrator in any project by copying the template and launching Claude Code:
+
+```bash
+cd your-project
+cp ~/.claude/templates/CLAUDE-ORCHESTRATOR.md ./CLAUDE.md
+claude
+```
+
+Done. The orchestrator is active. From here, just type `GodMode: <your request>`.
+
+---
+
+## Recommended MCP Servers
+
+These servers extend what the agents can do. The setup script installs them for you, but you can add them manually with the commands below.
+
+```bash
+# Memory — recommended for agents (persistent context across sessions)
+claude mcp add memory -- npx -y @modelcontextprotocol/server-memory
+
+# Browser automation & screenshots — REQUIRED for @tester
+claude mcp add playwright -- npx @playwright/mcp@latest
+
+# GitHub — recommended for @github-manager
+export GITHUB_TOKEN="your_token"
+claude mcp add github -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_TOKEN \
+  -- docker run -i --rm -e GITHUB_PERSONAL_ACCESS_TOKEN \
+  ghcr.io/github/github-mcp-server
+
+# Performance audits — optional
+claude mcp add lighthouse -- npx lighthouse-mcp
+
+# Accessibility testing — optional
+claude mcp add a11y -- npx a11y-mcp
+```
+
+| Server | Required? | Used by |
+|--------|-----------|---------|
+| `memory` | Recommended | All agents (persistent state) |
+| `playwright` | **Required** | @tester (screenshots at 3 viewports) |
+| `github` | Recommended | @github-manager (issues, PRs, releases) |
+| `lighthouse` | Optional | Performance audits |
+| `a11y` | Optional | Accessibility testing |
+
+---
+
+## Backup / Manual Prompt Install (fallback)
+
+If the setup script does not work on your system, use one of the prompt-based install paths instead. Open Claude Code and paste the contents of the relevant file.
+
+### Install prompts
+
+| Prompt | Description |
+|--------|-------------|
+| [`CCGM_Prompt_01-SystemInstall-Auto.md`](../CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Auto.md) | **Auto install** — one-shot, fully automated. Requires `--dangerously-skip-permissions` flag when launching Claude Code. |
+| [`CCGM_Prompt_01-SystemInstall-Manual.md`](../CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Manual.md) | **Manual install** — step-by-step with explicit confirmation at each stage. No special flags needed. |
+
+### Maintenance and recovery prompts
+
+| Prompt | Description |
+|--------|-------------|
+| [`CCGM_Prompt_98-Maintenance.md`](../CC-GodMode-Prompts/CCGM_Prompt_98-Maintenance.md) | Pull the latest agent and skill improvements after a `git pull`. |
+| [`CCGM_Prompt_99-ContextRestore.md`](../CC-GodMode-Prompts/CCGM_Prompt_99-ContextRestore.md) | Restore the orchestrator's behavior after a `/compact` or session reset. |
+
+---
+
+## Context Recovery
+
+The orchestrator is active whenever `CLAUDE.md` is present in your project. Normally you never need to do anything special — just type `GodMode: <your request>` and the orchestrator routes the work.
+
+Use the [ContextRestore prompt](../CC-GodMode-Prompts/CCGM_Prompt_99-ContextRestore.md) if you notice any of these symptoms:
+
+- Claude writes code directly instead of delegating to @builder
+- Claude forgets to call @api-guardian for API or type changes
+- Claude skips quality gates (@validator / @tester)
+- Claude tries to git push without asking for explicit permission
+
+Paste the ContextRestore prompt into the current session to re-establish the orchestrator role without starting a new session.
+
+---
+
+## Updating and Uninstalling
+
+### Updating
+
+Pull the latest changes and re-run the setup script:
+
+```bash
+cd ClaudeCode_GodMode-On
+git pull
+./scripts/apply-global-claude-setup.sh          # macOS / Linux
+# or
+.\scripts\apply-global-claude-setup.ps1         # Windows PowerShell
+```
+
+The script is idempotent — it is safe to re-run and will overwrite only the GodMode files in `~/.claude/`.
+
+After pulling, run the [Maintenance prompt](../CC-GodMode-Prompts/CCGM_Prompt_98-Maintenance.md) inside Claude Code to refresh agent context.
+
+### Uninstalling
+
+Uninstall instructions are embedded in the SystemInstall prompt files. Open either install prompt and follow the uninstall section at the bottom to remove agents, skills, and templates from `~/.claude/`.
+
+---
+
+## See Also
+
+- [README](../README.md) — Overview, architecture diagram, and daily usage patterns
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — Agent registry, routing logic, and workflow internals

--- a/docs/STORY.md
+++ b/docs/STORY.md
@@ -1,0 +1,71 @@
+# The Story & Design Philosophy
+
+---
+
+## The System That Builds Itself
+
+Welcome to the machine shop. Except the machines are building themselves — and they're getting better at it.
+
+**CC_GodMode v7.0.0 and v7.1.0 weren't built by hand.** They were planned, architected, implemented, validated, documented, and shipped by the exact agents defined in this repo. PRs [#22](https://github.com/cubetribe/ClaudeCode_GodMode-On/pull/22) and [#23](https://github.com/cubetribe/ClaudeCode_GodMode-On/pull/23) are proof. The orchestrator delegated to @architect for design, @builder for implementation, @validator and @tester for quality gates, and @scribe for documentation. Then it created the PR itself.
+
+**v8.0.0 went further.** That release was produced by a parallel dynamic workflow — 12 edit subagents fanned out across the codebase simultaneously, adversarially verified each other's output, and synthesized one coherent result. No human touched the implementation layer. The orchestrator dispatched, the agents executed, the system shipped itself.
+
+That's not marketing copy. That's what happened. Three consecutive releases — planned, built, validated, and shipped by the system's own agents.
+
+---
+
+## The Story
+
+It started simple: One developer, mass sleep deprivation, and a vision.
+
+**Phase 1:** Manual labor. Researching best practices. Reading docs. Testing prompts. Failing. Iterating. Building agent after agent. Workflow after workflow. Week after week.
+
+**Phase 2:** The system works. 8 specialized AI agents orchestrating themselves. Features get built. Bugs get fixed. Documentation writes itself. *"This is pretty good,"* I thought.
+
+**Phase 3:** January 6th, 2026. A thought: *"What if I use the system... to improve the system?"*
+
+I gave it one prompt. The orchestrator delegated to the research team. Analyzed its own architecture. Found inefficiencies. Proposed improvements. Implemented them. Validated itself. Documented the changes.
+
+**The loop closed.**
+
+**Phase 4:** You're reading this. An AI wrote parts of it. An AI will improve it. The experiment continues — and it's no longer clear where the experiment ends and the tool begins.
+
+---
+
+## Design Philosophy
+
+These principles were hard-won. They reflect how modern large language models actually work — not how older prompt-engineering folklore said they needed to be coaxed:
+
+- **Identity is one line.** Persona prompts like "You are a Senior Engineer with 15 years of experience" add nothing on models like Opus 4.8. The task description does the work. Agent files dropped the theater and kept the function.
+
+- **Capitals don't add weight.** Extensive CRITICAL/MUST/NEVER scaffolding in older agent definitions caused overtriggering — the model read emphasis everywhere and prioritized nothing. Per Anthropic's guidance, normal imperative phrasing is sufficient. Hard safety rules (never push without permission, @api-guardian is mandatory) keep their weight because they're genuinely non-negotiable, not because they're shouted.
+
+- **Effort fields instead of verbose instruction preambles.** Each agent carries an `effort:` frontmatter field (Claude Code ≥2.1.152) that tunes token budgets automatically. The right cognitive load, dialed in at the declaration layer — no long warm-up paragraphs needed inside the prompt.
+
+- **Smart Routing is the default.** The original system always ran every agent for every task. That was safe and expensive. The current system runs only what the risk level requires — an estimated 30–50% token reduction for standard features, with Full-Gates reserved for API changes, security surfaces, and breaking changes.
+
+- **Verdict contract instead of report re-reading.** Agents return a structured 3-bullet STATUS verdict directly to the orchestrator. The full on-disk report exists for humans and for BLOCKED escalations — the orchestrator doesn't need to re-parse a markdown file to continue the workflow.
+
+- **Plugin-based install is the primary path.** `.claude-plugin/plugin.json` is the modern distribution mechanism; the manual install scripts stay as a fallback. One-time setup, then the orchestrator loads from CLAUDE.md automatically.
+
+These aren't preferences. They're the output of the system analyzing itself and removing what wasn't working.
+
+---
+
+## The Meta
+
+This file was partly written by an AI.
+
+Specifically: an agent running inside the system described by this file, working from source material extracted from the README it helped write, producing a doc that will be improved by the next version of itself.
+
+The original README carried it as a footnote: *"This README was partly written by an AI. The system that wrote it will improve it. The loop continues."*
+
+That understated it.
+
+The loop isn't a curiosity anymore. It's the release process. The system plans its own upgrades, builds them, verifies them, documents them, and ships them. Each version is a little more capable than the last. Each release is a little less human-authored than the one before it.
+
+Whether that's exciting or unsettling probably depends on where you're standing.
+
+---
+
+*See also: [../README.md](../README.md)*


### PR DESCRIPTION
## Why
The README had reached **561 lines** and duplicated content that already lives in `docs/` (agents, workflows, modes, architecture, cost). This splits it into a lean, compelling entry point plus four focused guides — and fixes staleness found along the way.

## Changes
**README slimmed 561 → 224 lines** (−60%): hero, 30-second install, usage, "what is this", a condensed *Parallel-First & Ultracode* section, a condensed 15-agent roster, the rules, a documentation index, and a short FAQ — each linking out for depth.

**New guides:**
| File | Contents |
|---|---|
| [`docs/INSTALLATION.md`](docs/INSTALLATION.md) | Script install, MCP servers, prompt-based fallback, context recovery, updating/uninstalling |
| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Parallel-first orchestration, file structure, dual-location model, the hook, evolution |
| [`docs/AGENTS.md`](docs/AGENTS.md) | The 15-agent roster, dual quality gates, workflows, modes (incl. Ultracode/Max-Parallel) |
| [`docs/STORY.md`](docs/STORY.md) | Origin story, design philosophy, the meta |

**Staleness fixed:**
- Runtime agent tree now lists **all 15 agents** (added `security.md`).
- "12 skills" → **13 skills**.
- Version-agnostic headings (dropped stale "v7.0"); removed the stale "5.5.0" version example.

## Verification
- All internal links verified resolving across the README and the 4 new docs (automated check, zero broken).
- No version/alias changes; `CHANGELOG.md` untouched.

Built by fanning out 4 parallel builder subagents (one per guide) while the orchestrator wrote the slimmed README — dogfooding the parallel-first model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)