### PR TITLE
docs(prompts): complete v8.0.1 version sweep (install prompts + model-selection)

### DIFF
--- a/CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Auto.md
+++ b/CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Auto.md
@@ -1,6 +1,6 @@
 # CC_GodMode Installation Prompt
 
-> **Version:** 8.0.0
+> **Version:** 8.0.1
 > **Type:** SYSTEM INSTALL
 > **Prerequisite:** None (first-time installation)
 > **Frequency:** Once per machine
@@ -103,7 +103,7 @@ Before you execute anything, give the user the following message:
 ```
 ╔═══════════════════════════════════════════════════════════════════════════╗
 ║                                                                           ║
-║   CC_GodMode Installation v8.0.0 - The Ultracode Release                  ║
+║   CC_GodMode Installation v8.0.1 - The Ultracode Release                  ║
 ║                                                                           ║
 ╠═══════════════════════════════════════════════════════════════════════════╣
 ║                                                                           ║
@@ -591,13 +591,13 @@ After completing all steps, provide this summary to the user:
 ```
 ╔═══════════════════════════════════════════════════════════════════════════╗
 ║                                                                           ║
-║   CC_GodMode Installation Successful! v8.0.0 - The Ultracode Release      ║
+║   CC_GodMode Installation Successful! v8.0.1 - The Ultracode Release      ║
 ║                                                                           ║
 ╠═══════════════════════════════════════════════════════════════════════════╣
 ║                                                                           ║
 ║   INSTALLATION REPORT                                                     ║
 ║                                                                           ║
-║   Version:      8.0.0                                                     ║
+║   Version:      8.0.1                                                     ║
 ║   Agents:       [X]/15 installed (8 core + 1 security gate + 6 department)║
 ║   Skills:       [X]/11 installed                                          ║
 ║   Scripts:      [X]/15 installed                                          ║

--- a/CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Manual.md
+++ b/CC-GodMode-Prompts/CCGM_Prompt_01-SystemInstall-Manual.md
@@ -1,6 +1,6 @@
 # Manual Installation Guide
 
-> **Version:** 8.0.0
+> **Version:** 8.0.1
 > **Type:** SYSTEM INSTALL
 > **Prerequisite:** None (first-time installation)
 > **Frequency:** Once per machine
@@ -385,7 +385,7 @@ chmod +x ~/.claude/scripts/*.js
 
 ## Version
 
-CC_GodMode **v8.0.0 — The Ultracode Release**
+CC_GodMode **v8.0.1 — The Ultracode Release**
 
 See [CHANGELOG.md](./CHANGELOG.md) for details.
 

--- a/CC-GodMode-Prompts/CCGM_Prompt_02-ProjectActivation.md
+++ b/CC-GodMode-Prompts/CCGM_Prompt_02-ProjectActivation.md
@@ -1,6 +1,6 @@
 # CC_GodMode Orchestrator - Inject into CLAUDE.md
 
-> **Version:** 8.0.0 **Type:** PROJECT ACTIVATION **Prerequisite:**
+> **Version:** 8.0.1 **Type:** PROJECT ACTIVATION **Prerequisite:**
 > SystemInstall (01-SystemInstall-Auto or Manual) must be completed first
 > **Frequency:** Once per project
 

--- a/CC-GodMode-Prompts/CCGM_Prompt_98-Maintenance.md
+++ b/CC-GodMode-Prompts/CCGM_Prompt_98-Maintenance.md
@@ -1,4 +1,4 @@
-> **Version:** 8.0.0 **Type:** MAINTENANCE **Prerequisite:** SystemInstall and
+> **Version:** 8.0.1 **Type:** MAINTENANCE **Prerequisite:** SystemInstall and
 > ProjectActivation completed **Frequency:** Periodically (when checking for
 > updates)
 

--- a/CC-GodMode-Prompts/CCGM_Prompt_99-ContextRestore.md
+++ b/CC-GodMode-Prompts/CCGM_Prompt_99-ContextRestore.md
@@ -1,6 +1,6 @@
 # CC_GodMode Restart Prompt
 
-> **Version:** 8.0.0 **Type:** CONTEXT RESTORE **Prerequisite:** SystemInstall
+> **Version:** 8.0.1 **Type:** CONTEXT RESTORE **Prerequisite:** SystemInstall
 > and ProjectActivation completed **Frequency:** As-needed (after /compact or
 > context loss)
 
@@ -350,4 +350,4 @@ The system has meta-decision logic that adapts workflows:
 
 ---
 
-**CC_GodMode v6.4.0 - Enhanced Restart Prompt with Behavior Enforcement**
+**CC_GodMode v8.0.1 - Enhanced Restart Prompt with Behavior Enforcement**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bumped to `8.0.1` across `VERSION`, `.claude-plugin/plugin.json`, `CLAUDE.md`, `templates/CLAUDE-ORCHESTRATOR.md`, `README.md`, and `CC-GodMode-Prompts/QUICK_START.md`.
+- **Version-consistency sweep across the remaining current-state surfaces:** the install / project-activation / maintenance / context-restore prompt headers, the install welcome + success banners and the install-report version field (`CC-GodMode-Prompts/CCGM_Prompt_01/02/98/99*`), and the `docs/AGENT_MODEL_SELECTION.md` intro line — all bumped `8.0.0` → `8.0.1`. A stale `v6.4.0` footer in the context-restore prompt was also corrected. Historical references (`CHANGELOG.md`, `// vX.Y.Z:` feature-introduction comments, ADR/authored-at stamps, `archive/`) were deliberately left untouched, verified by an adversarial multi-agent classification pass (see `reports/v8.0.1/`).
 
 ---
 

--- a/docs/AGENT_MODEL_SELECTION.md
+++ b/docs/AGENT_MODEL_SELECTION.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-CC_GodMode v8.0.0 uses **three different Claude models** across its 15 agents (8 core + 1 security gate + 6 department) to optimize for cost vs. performance. This document explains:
+CC_GodMode v8.0.1 uses **three different Claude models** across its 15 agents (8 core + 1 security gate + 6 department) to optimize for cost vs. performance. This document explains:
 - Which model and effort level each agent uses and why
 - Ultracode Orchestrator economics
 - Cost implications per workflow with Smart Routing


### PR DESCRIPTION
## What
Completes the v8.0.1 bump that #31 landed. After #31, `VERSION` / `plugin.json` / `CLAUDE.md` / `README` / `QUICK_START` / the orchestrator template read `8.0.1`, but several **current-state surfaces** were left behind at `8.0.0` (and one at `v6.4.0`):

- Install / project-activation / maintenance / context-restore **prompt headers** (`> **Version:** 8.0.0`)
- Install **welcome + success banners** and the install-report **version field**
- Context-restore prompt **footer** stuck at `v6.4.0`
- `docs/AGENT_MODEL_SELECTION.md` intro line (`CC_GodMode v8.0.0 uses …`)

All now read `8.0.1`. **No `VERSION` change** — pure consistency, bringing stragglers up to the already-released 8.0.1. The existing `[8.0.1]` CHANGELOG "Changed" section is extended to record the sweep.

## Deliberately preserved (historical)
`CHANGELOG` history, `// vX.Y.Z:` feature-introduction comments, ADR/authored-at stamps, `archive/`, and narrative mentions of what v8.0.0 shipped (`README` story, `(v8.0.0)` section headers, MODES note).

## Verification
- Adversarial multi-agent classification of ~42 files / 197 version references (9 classifiers → per-group verifiers → completeness critic) to separate current-state declarations from historical refs.
- `node scripts/test-phase2-integration.js` → **7/7 (100%)** + 3/3 backwards-compat.
- `node scripts/sync-version.js --check` → all synchronized.

## Suggested landing
Merge **before** tagging `v8.0.1`, so the tag/release ships the complete sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)